### PR TITLE
bugfix: Set canvas to display: block

### DIFF
--- a/client/src/components/Showcase.vue
+++ b/client/src/components/Showcase.vue
@@ -99,5 +99,9 @@ watch(
 .pixi-canvas {
   height: 100%;
   width: 100%;
+
+  :deep(canvas) {
+    display: block;
+  }
 }
 </style>


### PR DESCRIPTION
The default `display: inline` lead to some overflow so changing it to `block` to get it to match the screen size.